### PR TITLE
Update linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -9,6 +9,8 @@
 
 """This module exports the Erlc plugin class."""
 
+import tempfile
+import os
 from SublimeLinter.lint import Linter, util
 
 
@@ -43,7 +45,11 @@ class Erlc(Linter):
 
         this func is overridden so we can handle included directories.
         """
-        command = [self.executable_path, '-W']
+        tmpdir = os.path.join(tempfile.gettempdir(), 'SublimeLinter3')
+        command = [
+            self.executable_path, '-W',
+            '-o', tmpdir
+        ]
 
         settings = self.get_view_settings()
         dirs = settings.get('include_dirs', [])


### PR DESCRIPTION
add tmpdir for output

Hey! I am not sure if this small change is necessary, but it annoys me to see *.beam file in my src dir. 
