### PR TITLE
SL4 compat: Set tempfile_suffix='-' to use file-only linting

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -42,7 +42,7 @@ class Erlc(Linter):
 
         this func is overridden so we can handle included directories.
         """
-        command = [self.executable_path, '-W']
+        command = ['erlc', '-W']
 
         settings = self.get_view_settings()
         dirs = settings.get('include_dirs', [])
@@ -60,5 +60,7 @@ class Erlc(Linter):
             command.extend(["-pz", d])
 
         command.extend(["-o", output_dir])
+
+        command.extend(["$file_on_disk"])
 
         return command

--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class Erlc(Linter):
     )
 
     executable = "erlc"
-    tempfile_suffix = "erl"
+    tempfile_suffix = "-"
 
     # ERROR FORMAT # <file>:<line>: [Warning:|] <message> #
     regex = (


### PR DESCRIPTION
SL4 switched to using tempfiles for all linting. This breaks erlc with include paths.

You can disable tempfiles with `tempfile_suffix = '-'` so that's what this PR does :)
http://www.sublimelinter.com/en/latest/linter_attributes.html#file-only-linters